### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ calendar events using GET parameters. The main goal to find available options â€
 
 ### JavaScript
 
- 1. [jekuer/add-to-calendar-button](https://github.com/jekuer/add-to-calendar-button) An up-to-date ValillaJS script to render "add to calendar" buttons from simple JSON.
+ 1. [add2cal/add-to-calendar-button](https://github.com/add2cal/add-to-calendar-button) An up-to-date ValillaJS script to render "add to calendar" buttons from simple JSON.
  1. [carlsednaoui/add-to-calendar-buttons](https://github.com/carlsednaoui/add-to-calendar-buttons) A simple ValillaJS library to add an "add to calendar" buttons for events.
  1. [jojoee/add2calendar](https://github.com/jojoee/add2calendar) A simple ValillaJS library that allows you to add event to calendar easier 
  1. [AnandChowdhary/calendar-link](https://github.com/AnandChowdhary/calendar-link) NPM package for generating calendar links for both Node.js and browsers


### PR DESCRIPTION
JavaScript repo "add-to-calendar-button" changed its host location.  
Old url still redirects, but to prevent future problems, it should be updated.