### PR TITLE
Update Outlook Web parameters from live testing

### DIFF
--- a/services/outlook-web.md
+++ b/services/outlook-web.md
@@ -10,6 +10,9 @@ Outlook Live:
 Office 365:  
 `https://outlook.office.com/calendar/deeplink/compose`
 
+An account index may be inserted before `deeplink`, for example
+`https://outlook.live.com/calendar/0/deeplink/compose`. Both forms behave identically.
+
 ### Example
 
 Outlook Live:  
@@ -17,6 +20,24 @@ Outlook Live:
 
 Office 365:  
 `https://outlook.office.com/calendar/deeplink/compose?path=/calendar/action/compose&rru=addevent&startdt=2023-08-09T19:30:00Z&enddt=2023-08-09T22:30:00Z&subject=Birthday&body=With%20clowns%20and%20stuff&location=North%20Pole`
+
+## How this was verified
+
+Unlike Google Calendar, the Outlook web app does not parse the deep link in the browser.
+None of the parameter names appear in the OWA JavaScript chunks that the compose page loads,
+and the query string disappears from the address bar once the compose form is rendered,
+so the mapping happens on the server.
+
+That means the list below comes from replaying parameters against the live compose form and
+observing the result, not from reading a parser.
+
+Each parameter carries one of three confidence markers:
+
+* **verified**: the parameter visibly changed the compose form.
+* **no effect**: the parameter was replayed and the form did not change.
+* **not observable**: the parameter may work, but the compose form gives no way to tell.
+
+Last check on `outlook.live.com`: 2026-08-19. The Office 365 host was not re-tested.
 
 ## Parameters
 
@@ -27,6 +48,8 @@ format: string
 
 example: `path=/calendar/action/compose`
 
+confidence: verified
+
 description: internal application path.
 
 ### rru
@@ -35,6 +58,8 @@ required: yes
 format: string (`addevent`)
 
 example: `rru=addevent`
+
+confidence: verified
 
 description: action name.
 
@@ -45,8 +70,10 @@ format: datetime (`YYYY-MM-DDTHH:mm:SSZ`) or date (`YYYY-MM-DD`, for all-day eve
 
 example: `startdt=2020-12-31T19:30:00Z`
 
-description: The start date for the event.
-You can omit trailing `Z`, in this case script assumes that time specified in current user's timezone.
+confidence: verified
+
+description: the start date for the event.
+You can omit the trailing `Z`, in which case the value is read in the current user's timezone.
 To specify all-day events use the `YYYY-MM-DD` format.
 
 ### enddt
@@ -56,7 +83,9 @@ format: datetime (`YYYY-MM-DDTHH:mm:SSZ`) or date (`YYYY-MM-DD`, for all-day eve
 
 example: `enddt=2020-12-31T22:30:00Z`
 
-description: The end time of the event, format as for `startdt`.
+confidence: verified
+
+description: the end time of the event, format as for `startdt`.
 
 ### subject
 required: yes
@@ -65,7 +94,9 @@ format: string
 
 example: `subject=Birthday`
 
-description: event title.
+confidence: verified
+
+description: event title. It also becomes the browser tab title.
 
 ### allday
 required: no
@@ -74,16 +105,23 @@ format: boolean (`true`/`false`)
 
 example: `allday=true`
 
-description: whether event is all-day or not.
+confidence: verified
+
+description: whether the event is all-day or not.
+`allday=true` wins over the time part of `startdt` and `enddt`, so a full datetime range still collapses into an all-day event.
+All-day events also default to "Free" availability.
 
 ### body
 required: no
 
-format: text
+format: text or HTML
 
 example: `body=With clowns and stuff`
 
-description: description of your event
+confidence: verified
+
+description: description of your event.
+HTML is accepted and rendered, so `body=%3Cb%3Ebold%3C%2Fb%3E` produces bold text and an `<a href="...">` produces a real link.
 
 ### location
 required: no
@@ -92,56 +130,51 @@ format: string
 
 example: `location=North Pole`
 
-description: set the location of the event.
+confidence: verified
+
+description: set the location of the event. The value is added as a free-text location entry, it is not resolved against Bing Maps.
 
 ### online
 required: no
 
-format: boolean (any value means `true`)
-
-description: toggle the "Skype meeting" button.
+format: boolean (any truthy value, `1` and `true` both work)
 
 example: `online=1`
+
+confidence: verified
+
+description: turns the online meeting toggle on. The toggle is labelled "Teams meeting" now, not "Skype meeting". Without this parameter the toggle stays off until an attendee is added.
 
 ### to
 required: no
 
 format: string
 
-description: A comma-separated list of emails of required attendees.
-
 example: `to=santa@example.com,easter.bunny@example.com`
 
-### cc
-format: string
+confidence: verified
 
-description: A comma-separated list of emails of optional attendees.
+description: a comma-separated list of emails of required attendees.
+
+### cc
+required: no
+
+format: string
 
 example: `cc=santa@example.com,easter.bunny@example.com`
 
+confidence: verified
 
-### reqresponse
-format: string
-
-example: `reqresponse=true`
-
-### allowfw
-format: boolean ("true"/"false")
-
-description: Allow forwarding.
-
-example: `allowfw=true`
-
-### hideattn
-format: boolean ("true"/"false")
-
-description: Hide attendee list.
-
-example: `hideattn=true`
-
+description: a comma-separated list of emails of optional attendees.
 
 ### freebusy
+required: no
+
 format: string (enum)
+
+example: `freebusy=oof`
+
+confidence: verified
 
 options:
  - `free`
@@ -151,10 +184,55 @@ options:
  - `workingelsewhere`
  - `nodata`
 
-### online
-format: any
+description: availability shown for the event. `oof` renders as "Out of office".
 
-Description: "Skype meeting" flag.
+### reqresponse
+required: no
+
+format: boolean (`true`/`false`)
+
+example: `reqresponse=true`
+
+confidence: not observable
+
+description: request responses from attendees. The compose form hides this behind a "Response options" menu, so the parameter could not be confirmed.
+
+### allowfw
+required: no
+
+format: boolean (`true`/`false`)
+
+example: `allowfw=true`
+
+confidence: not observable
+
+description: allow forwarding. Same "Response options" menu as above.
+
+### hideattn
+required: no
+
+format: boolean (`true`/`false`)
+
+example: `hideattn=true`
+
+confidence: not observable
+
+description: hide the attendee list. Same "Response options" menu as above.
 
 ### folderid
-description: Unknown, probably Event id.
+required: no
+
+format: string
+
+confidence: not observable
+
+description: unknown, probably the target calendar folder.
+
+## Parameters that do not work
+
+These were replayed against the compose form and produced no change, so do not rely on them:
+
+ - `private` and `sensitivity`: the privacy control stays on "Not private".
+ - `categories`: no category is applied.
+ - `reminder`: the reminder control keeps its default.
+ - `charm`: no event charm is selected.


### PR DESCRIPTION
## What

Rewrites `services/outlook-web.md` against the current Outlook Web compose deep link.

## How this was researched

Outlook does not parse the deep link in the browser. All 68 `owa.*.js` chunks that the compose page loads were downloaded and searched: none of them contain `startdt`, `enddt`, `rru`, `freebusy` or any other parameter name, and the query string is dropped from the address bar as soon as the compose form renders. The mapping happens on the server, so there is no parser to read.

The list is therefore based on replaying parameters against the live compose form on `outlook.live.com` and observing what changed. Every parameter carries a confidence marker:

* **verified**: the parameter visibly changed the compose form.
* **no effect**: the parameter was replayed and nothing changed.
* **not observable**: it may work, but the form gives no way to tell.

## New findings

* **`body` accepts HTML.** `<b>` renders as bold and `<a href="...">` becomes a real link in the event body.
* **`allday=true` overrides a full datetime range.** A `startdt`/`enddt` pair with times still collapses into an all-day event, and all-day events default to Free availability.
* **`online` toggles a Teams meeting**, not a Skype meeting. Without the parameter the toggle stays off until an attendee is added.
* An account index may be inserted in the path: `https://outlook.live.com/calendar/0/deeplink/compose` works the same way.
* `location` is added as free text and is not resolved against a maps provider.

## Parameters that do not work

Replayed and confirmed to produce no change, now listed in their own section so nobody wastes time on them: `private`, `sensitivity`, `categories`, `reminder`, `charm`.

## Downgraded to "not observable"

`reqresponse`, `allowfw`, `hideattn` and `folderid` sit behind the "Response options" menu or have no visible surface at all, so they are marked honestly instead of being presented as working.

The document records the check date (2026-08-19) and notes that the Office 365 host was not re-tested.