### PR TITLE
Recommend the render URL for cross-device links

### DIFF
--- a/services/google.md
+++ b/services/google.md
@@ -17,6 +17,10 @@ Other helpful resources:
 The `render` URL is a thin entry point: it redirects to `/calendar/u/0/r/eventedit` and keeps the whole query string.
 Everything below therefore applies to both URLs.
 
+Prefer `render` when you do not control the device the link is opened on. It is the form Google itself
+hands out, and it is reported to be the only one that reaches the event editor on Android, where the
+`eventedit` path opens the Google Calendar app without starting event creation (see issue #56).
+
 ## How this was verified
 
 The parameters below were recovered by reading the Google Calendar web client bundle


### PR DESCRIPTION
Follow-up to #59.

`https://calendar.google.com/calendar/render?action=TEMPLATE&...` answers with a redirect to `https://calendar.google.com/calendar/u/0/r/eventedit` and carries the whole query string across unchanged, so on the web both entry points reach the same editor with the same parameters.

Since the two are equivalent in a browser, there is no cost to preferring `render`, and [discussion 62](https://github.com/InteractionDesignFoundation/add-event-to-calendar-docs/discussions/62) reports it is the only form that starts event creation on Android (the `eventedit` path opens the Google Calendar app but stops there). The Basic URL section now says so.